### PR TITLE
Prevent exception in case of a 'STOP' command

### DIFF
--- a/mymqtt.py
+++ b/mymqtt.py
@@ -53,7 +53,7 @@ class MQTT(threading.Thread, MyLog):
                 self.LogInfo("sending message: "+str(msg))
                 if msg == "STOP":
                     self.shutter.stop(shutterId)
-                if int(msg) == 0:
+                elif int(msg) == 0:
                     self.shutter.lower(shutterId)
                 elif int(msg) == 100:
                     self.shutter.rise(shutterId)


### PR DESCRIPTION
In case 'STOP' is sent, this results in an exception:
Exception Occured: invalid literal for int() with base 10: 'STOP'

This is expected since 'STOP' can not be converted to int. 
The change of 'if' to 'elif' resolves this issue.