### PR TITLE
Feature/password

### DIFF
--- a/myconfig.py
+++ b/myconfig.py
@@ -30,6 +30,7 @@ class MyConfig (MyLog):
         self.Shutters = {}
         self.ShuttersByName = {}
         self.Schedule = {}
+        self.Password = ""
 
         try:
             self.config = RawConfigParser()
@@ -48,7 +49,7 @@ class MyConfig (MyLog):
     # -------------------- MyConfig::LoadConfig-----------------------------------
     def LoadConfig(self):
 
-        parameters = {'LogLocation': str, 'Latitude': float, 'Longitude': float, 'SendRepeat': int, 'UseHttps': bool, 'HTTPPort': int, 'HTTPSPort': int, 'TXGPIO': int, 'RTS_Address': str}
+        parameters = {'LogLocation': str, 'Latitude': float, 'Longitude': float, 'SendRepeat': int, 'UseHttps': bool, 'HTTPPort': int, 'HTTPSPort': int, 'TXGPIO': int, 'RTS_Address': str, "Password": str}
         
         self.SetSection("General");
         for key, type in parameters.items():

--- a/mywebserver.py
+++ b/mywebserver.py
@@ -67,6 +67,8 @@ class FlaskAppWrapper(MyLog):
         self.app.add_url_rule(endpoint, endpoint_name, EndpointAction(handler), methods=methods)
 
     def requestMain(self):
+        if not self.validatePassword(header=False):
+            return self.app.send_static_file("error.html")
         self.LogDebug(request.url)
         return self.app.send_static_file('index.html')
         
@@ -88,6 +90,17 @@ class FlaskAppWrapper(MyLog):
             self.LogErrorLine("Error in Process Command: " + command + ": " + str(e1))
             return Response("Error: Exception occured", status=400)
 
+    def validatePassword(self, header=True):
+        if header:
+            password = request.headers.get("Password")
+        else:
+            password = request.args.get("Password")
+        if password != self.config.Password:
+            self.LogDebug("received invalid password")
+            self.LogDebug(password)
+            return False
+        return True
+
     def shutdown_server(self):
         func = request.environ.get('werkzeug.server.shutdown')
         if func is None:
@@ -96,6 +109,8 @@ class FlaskAppWrapper(MyLog):
         return Response("Shutting Down", status=400)
         
     def up(self, params):
+        if not self.validatePassword():
+            return {'status': 'ERROR'}
         shutter=params.get('shutter', 0, type=str)
         self.LogDebug("rise shutter \""+shutter+"\"")
         if (not shutter in self.config.Shutters):
@@ -104,6 +119,8 @@ class FlaskAppWrapper(MyLog):
         return {'status': 'OK'}
 
     def down(self, params):
+        if not self.validatePassword():
+            return {'status': 'ERROR'}
         shutter=params.get('shutter', 0, type=str)
         self.LogDebug("lower shutter \""+shutter+"\"")
         if (not shutter in self.config.Shutters):
@@ -112,6 +129,8 @@ class FlaskAppWrapper(MyLog):
         return {'status': 'OK'}
 
     def stop(self, params):
+        if not self.validatePassword():
+            return {'status': 'ERROR'}
         shutter=params.get('shutter', 0, type=str)
         self.LogDebug("stop shutter \""+shutter+"\"")
         if (not shutter in self.config.Shutters):

--- a/mywebserver.py
+++ b/mywebserver.py
@@ -91,10 +91,17 @@ class FlaskAppWrapper(MyLog):
             return Response("Error: Exception occured", status=400)
 
     def validatePassword(self, header=True):
+        # If no password configured, it's OK
+        if self.config.Password == "":
+            return True
+
         if header:
+            # Support password from 'Password' header
             password = request.headers.get("Password")
         else:
+            # Support password from 'Password' url param
             password = request.args.get("Password")
+
         if password != self.config.Password:
             self.LogDebug("received invalid password")
             self.LogDebug(password)


### PR DESCRIPTION
Added option to provide password for the shutters to function,  this way not everyone who have access to your WiFi network will be able to control your shutters.   
In other words, if someone has your WiFi password, he won't necessarily be able to break into your home :P

This feature obviously  goes hand in hand with HTTPS support, without it anyone could just sniff promiscuously on your network and see the password in plain text.


When using a /cmd, I pass the password as a header  
When using the normal home page, I pass the password in a URI parameters  
I did this because it's more convenient for my setup, but it would be understandable if you would change it so the password will always pass as a URI parameter  

If an invalid password is provided, the user will receive an error message/page and a log will be written.  

The password is configured under the general section in the config file