### PR TITLE
Proposed pull request for issue #78 - myscheduler.py

### DIFF
--- a/myscheduler.py
+++ b/myscheduler.py
@@ -326,7 +326,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][2:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        self.shutter.risePartial(shutterId, s1)
+                                        if (self.shutter.getPosition(shutterId) < s1):   #Is Shutter below requested Position?
+                                            self.shutter.risePartial(shutterId, s1)
+                                        else:
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already at same or above requested position")
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.rise(shutterId)
@@ -335,7 +338,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][4:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        self.shutter.lowerPartial(shutterId, s1)
+                                        if (self.shutter.getPosition(shutterId) > s1):   #Is Shutter above requested Position?
+                                            self.shutter.lowerPartial(shutterId, s1)
+                                        else:
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already at same or below requested position") 
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.lower(shutterId)


### PR DESCRIPTION
Changes the behavior for the following problem:

An example:
Shutter A is fully opened in the morning an closed for 60% by scheduled operations lets say at 8:00. Shutter A should again be closed by scheduled operations for 60% at 13:00. Between 8:00 and 13:00 the shutter is operated manually.

What happens?

Lets say Shutter A is moved manually to position 40% between 8:00 and 12:00 --> At 13:00 nothing happens. You will find an error in the logfile

Lets say Shutter A is moved manually to position 80% between 8:00 and 12:00 --> At 13:00 Shutter A is moved to positon 60%. Everything is fine

Lets say Shutter A is not moved manually between 8:00 and 12:00 at all --> At 13:00 Shutter A is fully closed.