### PR TITLE
ixes error in command line operation see Nickduino#25

### DIFF
--- a/myconfig.py
+++ b/myconfig.py
@@ -157,7 +157,10 @@ class MyConfig (MyLog):
                 elif return_type == float:
                     return self.config.getfloat(self.Section, Entry)
                 elif return_type == int:
-                    return self.config.getint(self.Section, Entry)
+                    if self.config.get(self.Section, Entry) == 'None':
+                        return None
+                    else:             
+                        return self.config.getint(self.Section, Entry)
                 else:
                     self.LogErrorLine("Error in MyConfig:ReadValue: invalid type:" + str(return_type))
                     return default

--- a/myconfig.py
+++ b/myconfig.py
@@ -157,10 +157,7 @@ class MyConfig (MyLog):
                 elif return_type == float:
                     return self.config.getfloat(self.Section, Entry)
                 elif return_type == int:
-                    if self.config.get(self.Section, Entry) == 'None':
-                        return None
-                    else:
-                        return self.config.getint(self.Section, Entry)
+                    return self.config.getint(self.Section, Entry)
                 else:
                     self.LogErrorLine("Error in MyConfig:ReadValue: invalid type:" + str(return_type))
                     return default

--- a/myconfig.py
+++ b/myconfig.py
@@ -157,7 +157,10 @@ class MyConfig (MyLog):
                 elif return_type == float:
                     return self.config.getfloat(self.Section, Entry)
                 elif return_type == int:
-                    return self.config.getint(self.Section, Entry)
+                    if self.config.get(self.Section, Entry) == 'None':
+                        return None
+                    else:
+                        return self.config.getint(self.Section, Entry)
                 else:
                     self.LogErrorLine("Error in MyConfig:ReadValue: invalid type:" + str(return_type))
                     return default

--- a/myscheduler.py
+++ b/myscheduler.py
@@ -326,10 +326,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][2:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        if (self.shutter.getPosition(shutterId) <= s1):   #Is Shutter below requested Position?
+                                        if (self.shutter.getPosition(shutterId) < s1):   #Is Shutter below requested Position?
                                             self.shutter.risePartial(shutterId, s1)
                                         else:
-                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already above requested position")                                      
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already at same or above requested position")                                      
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.rise(shutterId)
@@ -338,10 +338,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][4:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        if (self.shutter.getPosition(shutterId) >= s1):   #Is Shutter above requested Position?
+                                        if (self.shutter.getPosition(shutterId) > s1):   #Is Shutter above requested Position?
                                             self.shutter.lowerPartial(shutterId, s1)
                                         else:
-                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already below requested position")                                         
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already at same or below requested position")                                         
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.lower(shutterId)

--- a/myscheduler.py
+++ b/myscheduler.py
@@ -326,7 +326,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][2:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        self.shutter.risePartial(shutterId, s1)
+                                        if (self.shutter.getPosition(shutterId) <= s1):   #Is Shutter below requested Position?
+                                            self.shutter.risePartial(shutterId, s1)
+                                        else:
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already above requested position")                                      
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.rise(shutterId)
@@ -335,7 +338,10 @@ class Scheduler(threading.Thread, MyLog):
                                     s = eventDetail[1][4:].strip()
                                     s1 = int(s) if s else -1
                                     if (0 < s1 < 100):
-                                        self.shutter.lowerPartial(shutterId, s1)
+                                        if (self.shutter.getPosition(shutterId) >= s1):   #Is Shutter above requested Position?
+                                            self.shutter.lowerPartial(shutterId, s1)
+                                        else:
+                                            self.LogWarn("Send action \""+eventDetail[1]+"\" to shutterId \""+shutterId+"\" was canceled! Shutter was already below requested position")                                         
                                     else :  
                                         for i in range(self.config.SendRepeat):
                                             self.shutter.lower(shutterId)


### PR DESCRIPTION
Fixes error massage in command line operation as mentioned by @Secarius  and @ssanden in Issue Nickduino#25
_Error in MyConfig:ReadValue: 0x279621: invalid literal for int() with base 10: 'None' : myconfig.py:160_

For the object _getint()_ None ist not an valid type. But None ist used as initial value in the config file

