### PR TITLE
change Tile server from Wikimedia to OpenStreetMap

### DIFF
--- a/html/operateShutters.js
+++ b/html/operateShutters.js
@@ -45,15 +45,10 @@ function GetStartupInfo(initMap)
 
 function setupMap(lat, lng) {
     mymap = L.map('mymap').setView([lat, lng], 13);
-    L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png', {
-        attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia</a>',
-        minZoom: 1,
-        maxZoom: 19
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 18,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(mymap);
-    // L.tileLayer('https://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
-    //    maxZoom: 18,
-    //    attribution: 'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-    // }).addTo(mymap);
 	
     marker = L.marker([lat, lng]).addTo(mymap)
     mymap.on('click', onMapClick);


### PR DESCRIPTION
The Wikimedia Maps service was "recently" hit with a large amount of traffic coming from non-Wikimedia websites
The Wikimedia Foundation system administrators decided to block all traffic to Wikimedia Maps from non-Wikimedia websites in order to ensure that it remained available for Wikimedia projects. 
source : https://phabricator.wikimedia.org/T245145