### PR TITLE
Avoid error if mqtt server is not available at startup

### DIFF
--- a/mymqtt.py
+++ b/mymqtt.py
@@ -108,9 +108,8 @@ class MQTT(threading.Thread, MyLog):
         while not self.shutdown_flag.is_set():
             # Loop until the server is available
             try:
+                self.LogInfo("Connecting to MQTT server")
                 self.t.connect(self.config.MQTT_Server,self.config.MQTT_Port)
-                self.LogInfo("Starting Listener Thread to listen to messages from MQTT")
-                self.t.loop_start()
                 if self.config.EnableDiscovery == True:
                     self.sendStartupInfo()
                 break
@@ -121,17 +120,15 @@ class MQTT(threading.Thread, MyLog):
 
         error = 0
         while not self.shutdown_flag.is_set():
-            # Loop and poll for incoming Echo requests
+            # Loop and poll for incoming requests
             try:
-                # Allow time for a ctrl-c to stop the process
-                time.sleep(2)
+                #NOTE: Timeout value must be smaller than MQTT keep_alive (which is 60s by default)
+                self.t.loop(timeout=30)
             except Exception as e:
                 error += 1
                 self.LogInfo("Critical exception " + str(error) + ": "+ str(e.args))
-                print("Trying not to shut down MQTT")
                 time.sleep(0.5) #Wait half a second when an exception occurs
-        
-        self.t.loop_stop()
+
         self.LogError("Received Signal to shut down MQTT thread")
         return
 


### PR DESCRIPTION
If the pi-somfy service is started concurrently with the mqtt server, it may happen that the mqtt server is not available when we try to establish the connection.
This throws the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Pi-Somfy/mymqtt.py", line 103, in run
    self.t.connect(self.config.MQTT_Server,self.config.MQTT_Port)
  File "/usr/local/lib/python3.8/dist-packages/paho/mqtt/client.py", line 941, in connect
    return self.reconnect()
  File "/usr/local/lib/python3.8/dist-packages/paho/mqtt/client.py", line 1075, in reconnect
    sock = self._create_socket_connection()
  File "/usr/local/lib/python3.8/dist-packages/paho/mqtt/client.py", line 3546, in _create_socket_connection
    return socket.create_connection(addr, source_address=source, timeout=self._keepalive)
  File "/usr/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/usr/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```

This PR fixes this behavior, catching the errors during connection and re-trying the connection after some seconds.