### PR TITLE
Allow the MQTT client ID to be set in the configuration file

### DIFF
--- a/defaultConfig.conf
+++ b/defaultConfig.conf
@@ -42,9 +42,11 @@ HTTPPort = 80
 HTTPSPort = 443
 
 # Lowest identifier used by the tool to assign unique 24bit 
-# ids for new remote. This value won;t change in the config file, instead
+# ids for new remote. This value won't change in the config file, instead
 # the tool will look for the next available address that has not been 
 # used yet.
+# If you are running more than one instance of PiSomfy you must ensure
+# each instance is set to a different value to avoid possible conflicts
 RTS_Address = 0x279620
 
 ###################################################################
@@ -65,6 +67,11 @@ MQTT_User = xxxxxxx
 
 # Password of the MQTT Server
 MQTT_Password = xxxxxxx
+
+# MQTT unique client identifier
+# If you are running more than one instance of PiSomfy you must ensure
+# each instance is set to a different value to avoid possible conflicts
+MQTT_ClientID = somfy-mqtt-bridge
 
 # If MQTT Discovery is enabled, simply add the folowing 2 lines to Home
 # Assistant's configuration.yaml file:

--- a/myconfig.py
+++ b/myconfig.py
@@ -27,6 +27,7 @@ class MyConfig (MyLog):
         self.HTTPPort = 80
         self.HTTPSPort = 443
         self.RTS_Address = "0x279620"
+        self.MQTT_ClientID = "somfy-mqtt-bridge"
         self.Shutters = {}
         self.ShuttersByName = {}
         self.Schedule = {}
@@ -60,7 +61,7 @@ class MyConfig (MyLog):
                 self.LogErrorLine("Missing config file or config file entries in Section General for key "+key+": " + str(e1))
                 return False
 
-        parameters = {'MQTT_Server': str, 'MQTT_Port': int, 'MQTT_User': str, 'MQTT_Password': str, 'EnableDiscovery': bool}
+        parameters = {'MQTT_Server': str, 'MQTT_Port': int, 'MQTT_User': str, 'MQTT_Password': str, 'MQTT_ClientID': str, 'EnableDiscovery': bool}
         
         self.SetSection("MQTT");
         for key, type in parameters.items():

--- a/mymqtt.py
+++ b/mymqtt.py
@@ -96,7 +96,7 @@ class MQTT(threading.Thread, MyLog):
         self.LogInfo("Entering MQTT polling loop")
 
         # Setup the mqtt client
-        self.t = paho.Client(client_id="somfy-mqtt-bridge")
+        self.t = paho.Client(client_id=self.config.MQTT_ClientID)
         if not (self.config.MQTT_Password.strip() == ""):
            self.t.username_pw_set(username=self.config.MQTT_User,password=self.config.MQTT_Password)
         self.t.on_connect = self.on_connect


### PR DESCRIPTION
This introduces a new MQTT_ClientID option to the config file
which allows you to set a separate MQTT Client ID value. This
is important as MQTT will only allow one client to connect
with each client ID, so if you have multiple instances of the
PiSomfy running, when each one connects without this change
it will disconnect any other instances from the MQTT broker.