### PR TITLE
Check if pigpio is connected during initialization

### DIFF
--- a/operateShutters.py
+++ b/operateShutters.py
@@ -443,12 +443,16 @@ class operateShutters(MyLog):
 
            try:
                pi = pigpio.pi()  # local GPIO only
-               self.LogInfo ("pigpio's pi instantiated")
+               if not pi.connected:
+                   self.LogError("pigpio connection could not be established. Check logs to get more details.")
+                   return False
+               else:
+                   self.LogInfo("pigpio's pi instantiated.")
            except Exception as e:
                start_pigpiod_exception = str(e)
-               self.LogError ("problem instantiating pi: {}".format(start_pigpiod_exception))
+               self.LogError("problem instantiating pi: {}".format(start_pigpiod_exception))
        else:
-           self.LogError ("start pigpiod was unsuccessful.")
+           self.LogError("start pigpiod was unsuccessful.")
            return False
        return True
 


### PR DESCRIPTION
The pigpio.pi may return without an established connection. Therefore, the connected variable must be verified after the call. The check is already done in other calls but there was one without the check.