### PR TITLE
Fix case-mangling issue

### DIFF
--- a/myconfig.py
+++ b/myconfig.py
@@ -117,7 +117,7 @@ class MyConfig (MyLog):
 
     #---------------------MyConfig::setCode---------------------------------
     def setCode(self, shutterId, code):
-        self.WriteValue(shutterId, str(code), section="ShutterRollingCodes");
+        self.WriteValue(shutterId, str(code).upper(), section="ShutterRollingCodes");
         self.Shutters[shutterId]['code'] = code
         
 


### PR DESCRIPTION
As with some others, I'm still getting occasional issues whereby the rolling code for a shutter gets written to a lowercase copy of the ID. Obviously, this only happens when you have more than 10 blinds, causing the IDs (which are in hex) to contain alphabetical characters rather than just numbers.

As a crude fix, without doing a full root-cause analysis (as Python is not really my bag), this PR forces the code to be uppercased before writing. This should fix the issue, if not the confusion (so long as your shutter IDs are in uppercase in the first place).