### PR TITLE
Alexa Discovery Temp Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.venv
+/__pycache__

--- a/fauxmo_config.json
+++ b/fauxmo_config.json
@@ -1,0 +1,19 @@
+{
+    "FAUXMO": {
+        "ip_address": "auto"
+    },
+    "PLUGINS": {
+        "SimpleHTTPPlugin": {
+            "DEVICES": [
+                {
+                    "name": "SOMFY",
+                    "on_cmd": "http://localhost:80/cmd/stop?shutter={SHUTTER_ID}",
+                    "off_cmd": "http://localhost:80/cmd/up?shutter={SHUTTER_ID}",
+                    "method": "POST",
+                    "initial_state": "on",
+                    "use_fake_state": true
+                }
+            ]
+        }
+    }
+}

--- a/shutters.service
+++ b/shutters.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 User=pi
-ExecStart=sudo /usr/bin/python3 /home/pi/Pi-Somfy/operateShutters.py -c /home/pi/Pi-Somfy/operateShutters.conf -a -e -m
+ExecStart=sudo bash /home/pi/Pi-Somfy/start.sh
 Environment=PYTHONUNBUFFERED=1
 Restart=on-failure
 Type=exec

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo /usr/bin/python3 /home/pi/Pi-Somfy/operateShutters.py -c /home/pi/Pi-Somfy/operateShutters.conf -a -m &
+fauxmo -c /home/pi/Pi-Somfy/fauxmo_config.json -vv


### PR DESCRIPTION
### As known, Alexa is unable to discover the blinds when running operateShutters.py -e.
At the moment, I created a temporary fix to overcome this by using https://github.com/n8henrie/fauxmo simultaneously with Pi-Somfy. 
This works by calling the HTTP API from the webserver to open and shut the blinds. 
You will need to find your shutter id with the networking tools in your web browser when manually operating the blinds via the web UI. 
The payload will contain the shutters id which you can update in fauxmo_config.json. You will need to reinstall the daemon service to use the new start-up script. 
To use multiple blinds within the alexa integration, add more devices to the fauxmo_config.json. 
Hopefully OP (@Nickduino) implements the up-to-date [fauxmo repo by @n8henrie](https://github.com/n8henrie/fauxmo) and can properly integrate it within the program so the process is much more streamlined and works as it should. 
Unfortunately, I don't have to time to research further into the project to make this work seamlessly but from what I can gather, Alexa now requires some sort of byte response as mandatory and in it's current configuration, Alexa does not receive a discovery response from the program, it could be because of this? 
I also saw somewhere that Alexa needs the state of the device - with the current implementation it uses a fake state but when you call Alexa and tell her to open the blinds it will set the device on and off accordingly anyway, it's only really annoying if you use the Alexa app for example and see that the device is 'on' (blinds open) when they are shut; still - turn the device off and on with the app and it works as usual. 
I did look over and see if there was a state handler within the program but I myself am not very familiarised with OOP and so didn't spend much time investigating. 
But, for now, this works and is a suitable enough fix for me. 
Additionally, you will need to alter the https://github.com/n8henrie/fauxmo files. 
Please see: https://github.com/n8henrie/fauxmo/issues/122 where this seperate issue is documented. 
That said, I am grateful for this project as I can now control my blinds hands-free.

### **PLEASE NOTE: fauxmo must be installed globally w/ sudo. Run: `sudo python3 -m pip install fauxmo`**