### PR TITLE
Pin Paho to <2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ephem
 configparser
 Flask
-paho-mqtt
+paho-mqtt < 2.0.0
 pigpio
 requests


### PR DESCRIPTION
Paho has recently been updated to 2.0.0 and has broken the current API. Some details can be found in this issue: https://github.com/eclipse/paho.mqtt.python/issues/814

`journalctl -u shutters.service -e` will show this output if Paho 2.0.0 is installed and the instruction on Pi-Somfy's readme are followed:

```
Exception in thread MQTT:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
 * Serving Flask app 'WebServer'
  File "/home/stue/Pi-Somfy/mymqtt.py", line 149, in run
 * Debug mode: off
    self.t = paho.Client(mqtt_client.CallbackAPIVersion.VERSION1, self.config.MQTT_ClientID)
NameError: name 'mqtt_client' is not defined
```

This change pins Paho to < 2.0.0 thus avoiding this error. 

If anyone would like to update Pi-Somfy to use Paho >= 2.0.0 then there are some instructions to follow: https://github.com/eclipse/paho.mqtt.python/blob/master/docs/migrations.rst