### PR TITLE
Fix accordion animation: smooth reveal and correct open/close behavior

### DIFF
--- a/html/operateShutters.js
+++ b/html/operateShutters.js
@@ -118,16 +118,27 @@ new MutationObserver(function() {
                         $(this).collapse('hide');
                     });
                 }
-                $el.addClass('show').hide().slideDown(350, function() {
+                // Use the CSS transition (transition: height 0.35s ease) so the browser
+                // applies the overflow clip natively on the GPU — fixes backdrop-filter
+                // child layers escaping a JS-driven jQuery slideDown clip.
+                $el.css({ display: 'block', height: '0px', overflow: 'hidden' });
+                var target = $el[0].scrollHeight;
+                $el[0].offsetHeight; // force reflow before transition starts
+                $el.addClass('show').css('height', target + 'px');
+                setTimeout(function() {
+                    $el.css({ height: '', overflow: '' });
                     $el.trigger('shown.collapse');
-                });
+                }, 360);
                 $('[data-target="#' + $el.attr('id') + '"]').removeClass('collapsed').attr('aria-expanded', 'true');
             } else if (action === 'hide') {
                 if (!$el.hasClass('show')) return;
-                $el.slideUp(350, function() {
-                    $el.removeClass('show');
+                $el.css({ height: $el[0].scrollHeight + 'px', overflow: 'hidden' });
+                $el[0].offsetHeight; // force reflow
+                $el.css('height', '0px');
+                setTimeout(function() {
+                    $el.removeClass('show').css({ display: '', height: '', overflow: '' });
                     $el.trigger('hidden.collapse');
-                });
+                }, 360);
                 $('[data-target="#' + $el.attr('id') + '"]').addClass('collapsed').attr('aria-expanded', 'false');
             }
         });


### PR DESCRIPTION
## What

Replaces the custom collapse plugin's \jQuery.slideDown\/\slideUp\ calls with a CSS-transition-driven approach.

## Why

\.table-wrapper\ elements use \ackdrop-filter: blur(8px)\, which promotes them to GPU compositor layers. Chrome does not honour a JavaScript-animated \overflow: hidden\ clip on compositor-layer children, so the bottom half of the **Physical Remotes** accordion section was popping in instead of being revealed smoothly.

Driving the animation via the existing \	ransition: height 0.35s ease\ rule on \.accordion-collapse\ lets the browser apply the clip natively on the GPU, making all content reveal uniformly.

## Bugs also fixed

Clearing the inline \display\ style in the hide callback (previously left as \display: block\) lets the CSS rule \.accordion-collapse.collapse { display: none }\ take effect properly, fixing two follow-on regressions introduced by the new Physical Remotes section:

- Closing a section caused it to immediately re-open.
- Opening a section did not close the already-open one.