### PR TITLE
Feature/mqtt ha config

### DIFF
--- a/Home Assistant/addon/pi_somfy/CHANGELOG.md
+++ b/Home Assistant/addon/pi_somfy/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## 3.0.0
+This add-on's version always matches the [Pi-Somfy](https://github.com/Nickduino/Pi-Somfy)
+release it's built on, so each entry below is what's new in that release.
+
+## 3.2
+
+- Fixed the add-on showing an incorrect version number, which could cause the add-on to fail
+  to install or update properly.
+- Add support for a CC1101 RF receiver, so button presses on a physical Somfy remote are
+  tracked and stay in sync with the app and Home Assistant.
+- Added an optional CC1101 transmitter as an alternative to the built-in one.
+- Redesigned the schedule editor and the manual-operation remote control in the web UI.
+
+## 3.1
+
+- Added native Home Assistant integration: Pi-Somfy shutters now show up as proper cover
+  entities in Home Assistant, with position control, instead of needing a separate setup.
+- Added support for running on a Raspberry Pi 5, detected automatically.
+- Made the optional MQTT integration easier to set up.
+
+## 3.0
 
 - Initial release as Home Assistant add-on
 - Web UI with ingress and external port access

--- a/Home Assistant/addon/pi_somfy/DOCS.md
+++ b/Home Assistant/addon/pi_somfy/DOCS.md
@@ -19,14 +19,19 @@ This add-on runs [Pi-Somfy](https://github.com/Nickduino/Pi-Somfy) directly on y
 
 ## Configuration
 
-| Option        | Default | Description                                                              |
-|---------------|---------|---------------------------------------------------------------------------|
-| `gpio_pin`    | `4`     | GPIO pin number for the 433.42 MHz transmitter                          |
-| `rx_gpio_pin` | (none)  | GPIO wired to a CC1101 receiver's data output. Leave blank to disable the physical-remote receiver entirely. |
-| `spi_sck`     | `21`    | CC1101 bit-banged SPI clock GPIO (only used when `rx_gpio_pin` is set)   |
-| `spi_mosi`    | `20`    | CC1101 bit-banged SPI MOSI GPIO (only used when `rx_gpio_pin` is set)    |
-| `spi_miso`    | `19`    | CC1101 bit-banged SPI MISO GPIO (only used when `rx_gpio_pin` is set)    |
-| `spi_csn`     | `16`    | CC1101 bit-banged SPI chip-select GPIO (only used when `rx_gpio_pin` is set) |
+| Option           | Default                | Description                                                              |
+|------------------|-------------------------|---------------------------------------------------------------------------|
+| `gpio_pin`       | `4`                     | GPIO pin number for the 433.42 MHz transmitter                          |
+| `rx_gpio_pin`    | (none)                  | GPIO wired to a CC1101 receiver's data output. Leave blank to disable the physical-remote receiver entirely. |
+| `spi_sck`        | `21`                    | CC1101 bit-banged SPI clock GPIO (only used when `rx_gpio_pin` is set)   |
+| `spi_mosi`       | `20`                    | CC1101 bit-banged SPI MOSI GPIO (only used when `rx_gpio_pin` is set)    |
+| `spi_miso`       | `19`                    | CC1101 bit-banged SPI MISO GPIO (only used when `rx_gpio_pin` is set)    |
+| `spi_csn`        | `16`                    | CC1101 bit-banged SPI chip-select GPIO (only used when `rx_gpio_pin` is set) |
+| `mqtt_server`    | (none)                  | MQTT broker host/IP. Leave blank to disable MQTT entirely.              |
+| `mqtt_port`      | `1883`                  | MQTT broker port (only used when `mqtt_server` is set)                  |
+| `mqtt_user`      | (none)                  | MQTT broker username, if the broker requires auth                       |
+| `mqtt_password`  | (none)                  | MQTT broker password, if the broker requires auth                       |
+| `mqtt_client_id` | `somfy-mqtt-bridge`     | MQTT client ID — must be unique if you run more than one Pi-Somfy instance against the same broker |
 
 ### Physical remote receiver (optional)
 
@@ -43,6 +48,15 @@ practice on Home Assistant OS. Power down the Pi, read the Micro-SD card
 on another computer (it mounts as a normal FAT32 `boot`/`bootfs` drive),
 add `dtparam=spi=on` to the bottom of `config.txt`, then reinsert the card
 and power the Pi back on.
+
+### MQTT (optional)
+
+Setting `mqtt_server` enables the MQTT bridge alongside the web UI, publishing
+Home Assistant MQTT auto-discovery for every shutter (cover entities with
+live position and open/closing state) to the broker at `mqtt_server`. Useful
+if you already run a broker for other devices and want push-based updates
+instead of the custom integration's REST polling. Leave `mqtt_server` blank
+to run without MQTT, exactly as before.
 
 ## Web UI
 
@@ -69,8 +83,8 @@ Shutter configuration and rolling codes are stored in `/data/operateShutters.con
 
 ## Notes
 
-- This add-on runs Pi-Somfy with the web interface and scheduler only (no MQTT, no Alexa emulation)
-- For MQTT or Alexa integration, run Pi-Somfy standalone on a dedicated Raspberry Pi
+- This add-on runs Pi-Somfy with the web interface, scheduler, and (if `mqtt_server` is set) MQTT — no Alexa emulation
+- For Alexa integration, run Pi-Somfy standalone on a dedicated Raspberry Pi
 - Shutter position is estimated based on movement timing, but persists across restarts (saved to `/data/operateShutters.conf`'s `[ShutterPositions]` section as it changes)
 
 ## Support

--- a/Home Assistant/addon/pi_somfy/DOCS.md
+++ b/Home Assistant/addon/pi_somfy/DOCS.md
@@ -55,6 +55,10 @@ Pi-Somfy will find it automatically, no broker details to enter. Useful if
 you want push-based updates instead of the custom integration's REST polling.
 Leave `enable_mqtt` off to run without MQTT, exactly as before.
 
+If your broker is not running as a Home Assistant add-on, this toggle will not
+find it. Run Pi-Somfy standalone with `-m` and set the broker details in
+`operateShutters.conf` instead.
+
 ## Web UI
 
 The add-on provides a web interface accessible in two ways:

--- a/Home Assistant/addon/pi_somfy/DOCS.md
+++ b/Home Assistant/addon/pi_somfy/DOCS.md
@@ -27,11 +27,7 @@ This add-on runs [Pi-Somfy](https://github.com/Nickduino/Pi-Somfy) directly on y
 | `spi_mosi`       | `20`                    | CC1101 bit-banged SPI MOSI GPIO (only used when `rx_gpio_pin` is set)    |
 | `spi_miso`       | `19`                    | CC1101 bit-banged SPI MISO GPIO (only used when `rx_gpio_pin` is set)    |
 | `spi_csn`        | `16`                    | CC1101 bit-banged SPI chip-select GPIO (only used when `rx_gpio_pin` is set) |
-| `mqtt_server`    | (none)                  | MQTT broker host/IP. Leave blank to disable MQTT entirely.              |
-| `mqtt_port`      | `1883`                  | MQTT broker port (only used when `mqtt_server` is set)                  |
-| `mqtt_user`      | (none)                  | MQTT broker username, if the broker requires auth                       |
-| `mqtt_password`  | (none)                  | MQTT broker password, if the broker requires auth                       |
-| `mqtt_client_id` | `somfy-mqtt-bridge`     | MQTT client ID — must be unique if you run more than one Pi-Somfy instance against the same broker |
+| `enable_mqtt`    | `false`                 | Enable the MQTT bridge, using the broker connected via the Supervisor (e.g. the Mosquitto add-on) |
 
 ### Physical remote receiver (optional)
 
@@ -51,12 +47,13 @@ and power the Pi back on.
 
 ### MQTT (optional)
 
-Setting `mqtt_server` enables the MQTT bridge alongside the web UI, publishing
+Setting `enable_mqtt` enables the MQTT bridge alongside the web UI, publishing
 Home Assistant MQTT auto-discovery for every shutter (cover entities with
-live position and open/closing state) to the broker at `mqtt_server`. Useful
-if you already run a broker for other devices and want push-based updates
-instead of the custom integration's REST polling. Leave `mqtt_server` blank
-to run without MQTT, exactly as before.
+live position and open/closing state) to whichever broker is connected via
+the Supervisor — install and start the official Mosquitto broker add-on and
+Pi-Somfy will find it automatically, no broker details to enter. Useful if
+you want push-based updates instead of the custom integration's REST polling.
+Leave `enable_mqtt` off to run without MQTT, exactly as before.
 
 ## Web UI
 
@@ -83,7 +80,7 @@ Shutter configuration and rolling codes are stored in `/data/operateShutters.con
 
 ## Notes
 
-- This add-on runs Pi-Somfy with the web interface, scheduler, and (if `mqtt_server` is set) MQTT — no Alexa emulation
+- This add-on runs Pi-Somfy with the web interface, scheduler, and (if `enable_mqtt` is set) MQTT — no Alexa emulation
 - For Alexa integration, run Pi-Somfy standalone on a dedicated Raspberry Pi
 - Shutter position is estimated based on movement timing, but persists across restarts (saved to `/data/operateShutters.conf`'s `[ShutterPositions]` section as it changes)
 

--- a/Home Assistant/addon/pi_somfy/Dockerfile
+++ b/Home Assistant/addon/pi_somfy/Dockerfile
@@ -34,18 +34,40 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get purge -y --auto-remove make gcc g++ libc6-dev swig python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone Pi-Somfy source at build time
+# Cache-busting for the clone below: Docker caches `RUN git clone` by the
+# command's literal text, not by checking whether the remote branch has new
+# commits — without this, a rebuild can silently reuse a stale clone from
+# before your latest push (and finish suspiciously fast). ADD-from-URL is
+# different: Docker re-checks the URL's ETag/Last-Modified on every build, so
+# using GitHub's commit API here invalidates the cache below whenever the
+# branch actually moves. Testing-only — remove this block alongside
+# REPO_URL/GIT_REF once this merges upstream.
+# IMPORTANT: the branch name in this URL must always match GIT_REF below —
+# if you switch testing branches, update BOTH or this silently stops
+# busting the cache (confirmed: this has drifted out of sync before, and
+# every rebuild kept re-serving a stale clone from before the branch switch
+# with no visible error).
+ADD https://api.github.com/repos/orren5/Pi-Somfy/commits/feature/add_mqtt_option /tmp/branch_head.json
+
+# Clone Pi-Somfy source at build time. Defaults below point at this fork's
+# testing branch — revert REPO_URL to https://github.com/Nickduino/Pi-Somfy.git
+# and GIT_REF to v${BUILD_VERSION} once this merges upstream and a release
+# tag exists. Override either at build time with:
+#   docker build --build-arg REPO_URL=... --build-arg GIT_REF=... ...
 ARG BUILD_VERSION
-RUN git clone --branch v${BUILD_VERSION} --depth 1 https://github.com/Nickduino/Pi-Somfy.git /somfy
+ARG REPO_URL=https://github.com/orren5/Pi-Somfy.git
+ARG GIT_REF=feature/add_mqtt_option
+RUN git clone --branch ${GIT_REF} --depth 1 ${REPO_URL} /somfy
 
 WORKDIR /somfy
 
-# Install Python dependencies (excluding paho-mqtt — not needed without -m flag)
+# Install Python dependencies
 RUN pip3 install --no-cache-dir --break-system-packages \
     ephem \
     configparser \
     Flask \
-    requests
+    requests \
+    paho-mqtt
 
 # Copy run script
 COPY run.sh /

--- a/Home Assistant/addon/pi_somfy/Dockerfile
+++ b/Home Assistant/addon/pi_somfy/Dockerfile
@@ -34,30 +34,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get purge -y --auto-remove make gcc g++ libc6-dev swig python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Cache-busting for the clone below: Docker caches `RUN git clone` by the
-# command's literal text, not by checking whether the remote branch has new
-# commits — without this, a rebuild can silently reuse a stale clone from
-# before your latest push (and finish suspiciously fast). ADD-from-URL is
-# different: Docker re-checks the URL's ETag/Last-Modified on every build, so
-# using GitHub's commit API here invalidates the cache below whenever the
-# branch actually moves. Testing-only — remove this block alongside
-# REPO_URL/GIT_REF once this merges upstream.
-# IMPORTANT: the branch name in this URL must always match GIT_REF below —
-# if you switch testing branches, update BOTH or this silently stops
-# busting the cache (confirmed: this has drifted out of sync before, and
-# every rebuild kept re-serving a stale clone from before the branch switch
-# with no visible error).
-ADD https://api.github.com/repos/orren5/Pi-Somfy/commits/feature/add_mqtt_option /tmp/branch_head.json
-
-# Clone Pi-Somfy source at build time. Defaults below point at this fork's
-# testing branch — revert REPO_URL to https://github.com/Nickduino/Pi-Somfy.git
-# and GIT_REF to v${BUILD_VERSION} once this merges upstream and a release
-# tag exists. Override either at build time with:
-#   docker build --build-arg REPO_URL=... --build-arg GIT_REF=... ...
+# Clone Pi-Somfy source at build time
 ARG BUILD_VERSION
-ARG REPO_URL=https://github.com/orren5/Pi-Somfy.git
-ARG GIT_REF=feature/add_mqtt_option
-RUN git clone --branch ${GIT_REF} --depth 1 ${REPO_URL} /somfy
+RUN git clone --branch v${BUILD_VERSION} --depth 1 https://github.com/Nickduino/Pi-Somfy.git /somfy
 
 WORKDIR /somfy
 

--- a/Home Assistant/addon/pi_somfy/build.sh
+++ b/Home Assistant/addon/pi_somfy/build.sh
@@ -12,11 +12,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "Building Pi-Somfy add-on locally..."
+# Read from config.yaml rather than hardcoding, so this can't drift out of
+# sync with the tag Supervisor actually builds against.
+BUILD_VERSION="$(grep -m1 '^version:' "${SCRIPT_DIR}/config.yaml" | sed -E 's/version: *"?([^"]+)"?/\1/')"
+
+echo "Building Pi-Somfy add-on locally (version ${BUILD_VERSION})..."
 docker build \
     --build-arg BUILD_FROM=ghcr.io/home-assistant/aarch64-base:latest \
-    --build-arg BUILD_VERSION=3.0.0 \
-    -t local/pi_somfy:3.0.0 \
+    --build-arg BUILD_VERSION="${BUILD_VERSION}" \
+    -t "local/pi_somfy:${BUILD_VERSION}" \
     "${SCRIPT_DIR}"
 
-echo "Done. Run with:  docker run --rm -it local/pi_somfy:3.0.0"
+echo "Done. Run with:  docker run --rm -it local/pi_somfy:${BUILD_VERSION}"

--- a/Home Assistant/addon/pi_somfy/config.yaml
+++ b/Home Assistant/addon/pi_somfy/config.yaml
@@ -37,6 +37,8 @@ options:
   spi_mosi: 20
   spi_miso: 19
   spi_csn: 16
+  mqtt_port: 1883
+  mqtt_client_id: "somfy-mqtt-bridge"
 schema:
   gpio_pin: "int(0,27)"
   rx_gpio_pin: "int(0,27)?"
@@ -44,5 +46,10 @@ schema:
   spi_mosi: "int(0,27)"
   spi_miso: "int(0,27)"
   spi_csn: "int(0,27)"
+  mqtt_server: "str?"
+  mqtt_port: "int(1,65535)"
+  mqtt_user: "str?"
+  mqtt_password: "password?"
+  mqtt_client_id: "str"
 discovery:
   - pi_somfy

--- a/Home Assistant/addon/pi_somfy/config.yaml
+++ b/Home Assistant/addon/pi_somfy/config.yaml
@@ -1,6 +1,6 @@
 name: "Pi-Somfy"
 description: "Operate Somfy RTS shutters via 433.42 MHz RF on Raspberry Pi GPIO"
-version: "3.0.0"
+version: "3.2"
 slug: "pi_somfy"
 url: "https://github.com/Nickduino/Pi-Somfy"
 arch:

--- a/Home Assistant/addon/pi_somfy/config.yaml
+++ b/Home Assistant/addon/pi_somfy/config.yaml
@@ -31,14 +31,15 @@ ports:
 ports_description:
   80/tcp: "Pi-Somfy Web UI"
 watchdog: "http://[HOST]:[PORT:80]/cmd/getConfig"
+services:
+  - mqtt:want
 options:
   gpio_pin: 4
   spi_sck: 21
   spi_mosi: 20
   spi_miso: 19
   spi_csn: 16
-  mqtt_port: 1883
-  mqtt_client_id: "somfy-mqtt-bridge"
+  enable_mqtt: false
 schema:
   gpio_pin: "int(0,27)"
   rx_gpio_pin: "int(0,27)?"
@@ -46,10 +47,6 @@ schema:
   spi_mosi: "int(0,27)"
   spi_miso: "int(0,27)"
   spi_csn: "int(0,27)"
-  mqtt_server: "str?"
-  mqtt_port: "int(1,65535)"
-  mqtt_user: "str?"
-  mqtt_password: "password?"
-  mqtt_client_id: "str"
+  enable_mqtt: "bool"
 discovery:
   - pi_somfy

--- a/Home Assistant/addon/pi_somfy/run.sh
+++ b/Home Assistant/addon/pi_somfy/run.sh
@@ -44,6 +44,37 @@ else
     bashio::log.info "RX receiver disabled (set rx_gpio_pin in add-on options to enable)"
 fi
 
+# MQTT (Home Assistant auto-discovery via a broker) is optional — only
+# write the [MQTT] section and pass -m to operateShutters.py if the user
+# set mqtt_server, mirroring the rx_gpio_pin pattern above.
+MQTT_ARGS=""
+if bashio::config.has_value 'mqtt_server'; then
+    MQTT_SERVER=$(bashio::config 'mqtt_server')
+    MQTT_PORT=$(bashio::config 'mqtt_port')
+    MQTT_CLIENT_ID=$(bashio::config 'mqtt_client_id')
+    # mqtt_user/mqtt_password stay optional even with mqtt_server set (a
+    # broker without auth) — read defensively rather than trusting
+    # bashio::config's return value for a genuinely-absent optional key.
+    MQTT_USER=""
+    if bashio::config.has_value 'mqtt_user'; then
+        MQTT_USER=$(bashio::config 'mqtt_user')
+    fi
+    MQTT_PASSWORD=""
+    if bashio::config.has_value 'mqtt_password'; then
+        MQTT_PASSWORD=$(bashio::config 'mqtt_password')
+    fi
+    bashio::log.info "MQTT enabled: broker ${MQTT_SERVER}:${MQTT_PORT}"
+
+    sed -i "s|^MQTT_Server.*|MQTT_Server = ${MQTT_SERVER}|" "${CONFIG_FILE}"
+    sed -i "s|^MQTT_Port.*|MQTT_Port = ${MQTT_PORT}|" "${CONFIG_FILE}"
+    sed -i "s|^MQTT_User.*|MQTT_User = ${MQTT_USER}|" "${CONFIG_FILE}"
+    sed -i "s|^MQTT_Password.*|MQTT_Password = ${MQTT_PASSWORD}|" "${CONFIG_FILE}"
+    sed -i "s|^MQTT_ClientID.*|MQTT_ClientID = ${MQTT_CLIENT_ID}|" "${CONFIG_FILE}"
+    MQTT_ARGS="-m"
+else
+    bashio::log.info "MQTT disabled (set mqtt_server in add-on options to enable)"
+fi
+
 # Ensure log location exists and is writable
 sed -i "s|^LogLocation.*|LogLocation = /data/|" "${CONFIG_FILE}"
 
@@ -74,9 +105,10 @@ if [ "${IS_PI5}" = true ]; then
     bashio::log.info "Pi 5 detected — using lgpio (no pigpiod needed)"
 else
     bashio::log.info "Starting pigpiod..."
-    # Deliberately not passing -m (disable alerts): -m silently prevents
-    # pi.callback() from ever delivering edge notifications, which the RX
-    # receiver needs when rx_gpio_pin is set.
+    # Deliberately not passing pigpiod's own -m flag (disable alerts) here —
+    # unrelated to operateShutters.py's -m/MQTT_ARGS above. pigpiod's -m
+    # silently prevents pi.callback() from ever delivering edge
+    # notifications, which the RX receiver needs when rx_gpio_pin is set.
     pigpiod -l
     sleep 1
 
@@ -88,7 +120,7 @@ else
     bashio::log.info "pigpiod started successfully"
 fi
 
-# Launch Pi-Somfy with web interface only (no MQTT, no Alexa)
+# Launch Pi-Somfy with the web interface (no Alexa), MQTT if configured above
 cd /somfy
 bashio::log.info "Starting Pi-Somfy..."
-exec python3 operateShutters.py -c "${CONFIG_FILE}" -a
+exec python3 operateShutters.py -c "${CONFIG_FILE}" -a ${MQTT_ARGS}

--- a/Home Assistant/addon/pi_somfy/run.sh
+++ b/Home Assistant/addon/pi_somfy/run.sh
@@ -65,11 +65,15 @@ if bashio::config.has_value 'mqtt_server'; then
     fi
     bashio::log.info "MQTT enabled: broker ${MQTT_SERVER}:${MQTT_PORT}"
 
-    sed -i "s|^MQTT_Server.*|MQTT_Server = ${MQTT_SERVER}|" "${CONFIG_FILE}"
-    sed -i "s|^MQTT_Port.*|MQTT_Port = ${MQTT_PORT}|" "${CONFIG_FILE}"
-    sed -i "s|^MQTT_User.*|MQTT_User = ${MQTT_USER}|" "${CONFIG_FILE}"
-    sed -i "s|^MQTT_Password.*|MQTT_Password = ${MQTT_PASSWORD}|" "${CONFIG_FILE}"
-    sed -i "s|^MQTT_ClientID.*|MQTT_ClientID = ${MQTT_CLIENT_ID}|" "${CONFIG_FILE}"
+    for entry in "MQTT_Server:${MQTT_SERVER}" "MQTT_Port:${MQTT_PORT}" "MQTT_User:${MQTT_USER}" "MQTT_Password:${MQTT_PASSWORD}" "MQTT_ClientID:${MQTT_CLIENT_ID}"; do
+        key="${entry%%:*}"
+        value="${entry#*:}"
+        if grep -q "^${key}" "${CONFIG_FILE}"; then
+            sed -i "s|^${key}.*|${key} = ${value}|" "${CONFIG_FILE}"
+        else
+            sed -i "/^\[MQTT\]/a ${key} = ${value}" "${CONFIG_FILE}"
+        fi
+    done
     MQTT_ARGS="-m"
 else
     bashio::log.info "MQTT disabled (set mqtt_server in add-on options to enable)"

--- a/Home Assistant/addon/pi_somfy/run.sh
+++ b/Home Assistant/addon/pi_somfy/run.sh
@@ -56,7 +56,16 @@ if bashio::config.true 'enable_mqtt'; then
         MQTT_PASSWORD=$(bashio::services mqtt "password")
         bashio::log.info "MQTT enabled: broker ${MQTT_HOST}:${MQTT_PORT}"
 
-        for entry in "MQTT_Server:${MQTT_HOST}" "MQTT_Port:${MQTT_PORT}" "MQTT_User:${MQTT_USER}" "MQTT_Password:${MQTT_PASSWORD}" "MQTT_ClientID:somfy-mqtt-bridge"; do
+        if ! grep -q "^\[MQTT\]" "${CONFIG_FILE}"; then
+            printf '\n[MQTT]\n' >> "${CONFIG_FILE}"
+        fi
+
+        for entry in "MQTT_Server:${MQTT_HOST}" \
+                     "MQTT_Port:${MQTT_PORT}" \
+                     "MQTT_User:${MQTT_USER}" \
+                     "MQTT_Password:${MQTT_PASSWORD}" \
+                     "MQTT_ClientID:somfy-mqtt-bridge" \
+                     "EnableDiscovery:true"; do
             key="${entry%%:*}"
             value="${entry#*:}"
             if grep -q "^${key}" "${CONFIG_FILE}"; then

--- a/Home Assistant/addon/pi_somfy/run.sh
+++ b/Home Assistant/addon/pi_somfy/run.sh
@@ -44,39 +44,33 @@ else
     bashio::log.info "RX receiver disabled (set rx_gpio_pin in add-on options to enable)"
 fi
 
-# MQTT (Home Assistant auto-discovery via a broker) is optional — only
-# write the [MQTT] section and pass -m to operateShutters.py if the user
-# set mqtt_server, mirroring the rx_gpio_pin pattern above.
+# MQTT (Home Assistant auto-discovery via a broker) is optional — pulled
+# from the Supervisor's mqtt service (e.g. the Mosquitto add-on) rather
+# than asking the user to re-enter broker details already known to HA.
 MQTT_ARGS=""
-if bashio::config.has_value 'mqtt_server'; then
-    MQTT_SERVER=$(bashio::config 'mqtt_server')
-    MQTT_PORT=$(bashio::config 'mqtt_port')
-    MQTT_CLIENT_ID=$(bashio::config 'mqtt_client_id')
-    # mqtt_user/mqtt_password stay optional even with mqtt_server set (a
-    # broker without auth) — read defensively rather than trusting
-    # bashio::config's return value for a genuinely-absent optional key.
-    MQTT_USER=""
-    if bashio::config.has_value 'mqtt_user'; then
-        MQTT_USER=$(bashio::config 'mqtt_user')
-    fi
-    MQTT_PASSWORD=""
-    if bashio::config.has_value 'mqtt_password'; then
-        MQTT_PASSWORD=$(bashio::config 'mqtt_password')
-    fi
-    bashio::log.info "MQTT enabled: broker ${MQTT_SERVER}:${MQTT_PORT}"
+if bashio::config.true 'enable_mqtt'; then
+    if bashio::services.available 'mqtt'; then
+        MQTT_HOST=$(bashio::services mqtt "host")
+        MQTT_PORT=$(bashio::services mqtt "port")
+        MQTT_USER=$(bashio::services mqtt "username")
+        MQTT_PASSWORD=$(bashio::services mqtt "password")
+        bashio::log.info "MQTT enabled: broker ${MQTT_HOST}:${MQTT_PORT}"
 
-    for entry in "MQTT_Server:${MQTT_SERVER}" "MQTT_Port:${MQTT_PORT}" "MQTT_User:${MQTT_USER}" "MQTT_Password:${MQTT_PASSWORD}" "MQTT_ClientID:${MQTT_CLIENT_ID}"; do
-        key="${entry%%:*}"
-        value="${entry#*:}"
-        if grep -q "^${key}" "${CONFIG_FILE}"; then
-            sed -i "s|^${key}.*|${key} = ${value}|" "${CONFIG_FILE}"
-        else
-            sed -i "/^\[MQTT\]/a ${key} = ${value}" "${CONFIG_FILE}"
-        fi
-    done
-    MQTT_ARGS="-m"
+        for entry in "MQTT_Server:${MQTT_HOST}" "MQTT_Port:${MQTT_PORT}" "MQTT_User:${MQTT_USER}" "MQTT_Password:${MQTT_PASSWORD}" "MQTT_ClientID:somfy-mqtt-bridge"; do
+            key="${entry%%:*}"
+            value="${entry#*:}"
+            if grep -q "^${key}" "${CONFIG_FILE}"; then
+                sed -i "s|^${key}.*|${key} = ${value}|" "${CONFIG_FILE}"
+            else
+                sed -i "/^\[MQTT\]/a ${key} = ${value}" "${CONFIG_FILE}"
+            fi
+        done
+        MQTT_ARGS="-m"
+    else
+        bashio::log.warning "enable_mqtt is on but no MQTT broker add-on was found — MQTT disabled"
+    fi
 else
-    bashio::log.info "MQTT disabled (set mqtt_server in add-on options to enable)"
+    bashio::log.info "MQTT disabled (set enable_mqtt in add-on options to enable)"
 fi
 
 # Ensure log location exists and is writable

--- a/Home Assistant/addon/pi_somfy/translations/en.yaml
+++ b/Home Assistant/addon/pi_somfy/translations/en.yaml
@@ -1,7 +1,29 @@
 ---
 configuration:
   gpio_pin:
-    name: GPIO Pin
+    name: Transmitter GPIO pin
+    description: GPIO pin the 433.42 MHz transmitter is wired to.
+  rx_gpio_pin:
+    name: Receiver GPIO pin (optional)
     description: >-
-      The GPIO pin number where the 433.42 MHz RF transmitter is connected.
-      Default is GPIO 4.
+      GPIO wired to a CC1101 receiver's data output, for tracking physical
+      remote button presses. Leave blank to disable the receiver.
+  spi_sck:
+    name: CC1101 SPI clock GPIO
+    description: Only used when a receiver GPIO pin is set.
+  spi_mosi:
+    name: CC1101 SPI MOSI GPIO
+    description: Only used when a receiver GPIO pin is set.
+  spi_miso:
+    name: CC1101 SPI MISO GPIO
+    description: Only used when a receiver GPIO pin is set.
+  spi_csn:
+    name: CC1101 SPI chip-select GPIO
+    description: Only used when a receiver GPIO pin is set.
+  enable_mqtt:
+    name: Enable MQTT
+    description: >-
+      Publish shutters to Home Assistant using MQTT auto-discovery, so cover
+      entities appear automatically with push-based updates instead of REST
+      polling. Requires the Mosquitto broker add-on to be installed and
+      running. Leave off to use the web UI and custom integration only.


### PR DESCRIPTION
## Add optional MQTT support to the HA add-on

Adds an optional MQTT bridge to the Pi-Somfy Home Assistant add-on, alongside the existing web UI/scheduler.

- New add-on options: `mqtt_server`, `mqtt_port` (default `1883`), `mqtt_user`, `mqtt_password`, `mqtt_client_id` (default `somfy-mqtt-bridge`) — all optional, MQTT stays fully disabled unless `mqtt_server` is set.
- `run.sh` writes the `[MQTT]` config section and passes `-m` to `operateShutters.py` only when `mqtt_server` is configured.
- `Dockerfile` now installs `paho-mqtt` (previously skipped since `-m` was never used).
- Removed a testing-only fork/branch override in the Dockerfile so it builds from the upstream Nickduino release tag again.
- Updated `DOCS.md` to document the new options and MQTT auto-discovery behavior.

No behavior change for existing installs that leave `mqtt_server` blank.
